### PR TITLE
Update documentation to address CRAN notes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,14 @@
 Package: gamlr  
 Title:  Gamma Lasso Regression  
 Version: 1.13-8
-Author: Matt Taddy <mataddy@gmail.com>  
-Maintainer: Matt Taddy <mataddy@gmail.com>  
+Authors@R: person(given = "Matt",
+                  family = "Taddy",
+                  role = c("aut", "cre"),
+                  email = "mataddy@gmail.com")
 Depends: R (>= 2.15), Matrix, methods, graphics, stats
 Suggests: parallel    
-Description: The gamma lasso algorithm provides regularization paths corresponding to a range of non-convex cost functions between L0 and L1 norms.  As much as possible, usage for this package is analogous to that for the glmnet package (which does the same thing for penalization between L1 and L2 norms).  For details see: Taddy (2017 JCGS), 'One-Step Estimator Paths for Concave Regularization', <arXiv:1308.5623>.
+Description: The gamma lasso algorithm provides regularization paths corresponding to a range of non-convex cost functions between L0 and L1 norms.  As much as possible, usage for this package is analogous to that for the glmnet package (which does the same thing for penalization between L1 and L2 norms).  For details see: Taddy (2017 JCGS), 'One-Step Estimator Paths for Concave Regularization', <doi:10.48550/arXiv.1308.5623>.
 License: GPL-3  
 URL: https://github.com/TaddyLab/gamlr
+BugReports: https://github.com/TaddyLab/gamlr/issues
 

--- a/man/naref.Rd
+++ b/man/naref.Rd
@@ -10,10 +10,10 @@ naref(x, impute=FALSE, pzero=0.5)
 \item{impute}{ Logical, whether to impute missing values in numeric columns.}
 \item{pzero}{ If \code{impute==TRUE}, then if more than \code{pzero} of the values in a column are zero do zero imputation, else do mean imputation.}
 }
-\details{ For every \code{factor} or \code{character} column in \code{x}, \code{naref} sets \code{NA} as the reference level for a \code{factor} variable. Columns coded as \code{character} class are first converted to factors via \R{factor(x)}.  If \code{impute=TRUE} then the numeric columns are converted to two columns, one appended \code{.x} that contains imputed values and another appended \code{.miss} which is a binary variable indicating whether the original value was missing.  Numeric columns are returned without change if \code{impute=FALSE} or if they do not contain any missing values.  
+\details{ For every \code{factor} or \code{character} column in \code{x}, \code{naref} sets \code{NA} as the reference level for a \code{factor} variable. Columns coded as \code{character} class are first converted to factors via base R \code{factor(x)}.  If \code{impute=TRUE} then the numeric columns are converted to two columns, one appended \code{.x} that contains imputed values and another appended \code{.miss} which is a binary variable indicating whether the original value was missing.  Numeric columns are returned without change if \code{impute=FALSE} or if they do not contain any missing values.
 }
 \value{
-  A data frame where the factor and character columns have been converted to factors with reference level \code{NA}, and if \code{impute=TRUE} the missing values in numeric columns have been imputed and a flag for missingness has been added.  See details.   
+  A data frame where the factor and character columns have been converted to factors with reference level \code{NA}, and if \code{impute=TRUE} the missing values in numeric columns have been imputed and a flag for missingness has been added.  See details.
 }
 \author{
   Matt Taddy \email{mataddy@gmail.com}


### PR DESCRIPTION
### CRAN notes

```
Version: 1.13-8
Check: CRAN incoming feasibility
Result: NOTE 
  Maintainer: ‘Matt Taddy <mataddy@gmail.com>’
  
  No Authors@R field in DESCRIPTION.
  Please add one, modifying
    Authors@R: person(given = "Matt",
                      family = "Taddy",
                      role = c("aut", "cre"),
                      email = "mataddy@gmail.com")
  as necessary.
  
  The Description field contains
    Paths for Concave Regularization', <arXiv:1308.5623>.
  Please refer to arXiv e-prints via their arXiv DOI <doi:10.48550/arXiv.YYMM.NNNNN>.
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/gamlr-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/gamlr-00check.html)

Version: 1.13-8
Check: Rd files
Result: NOTE 
  checkRd: (-1) naref.Rd:13: Lost braces
      13 | \details{ For every \code{factor} or \code{character} column in \code{x}, \code{naref} sets \code{NA} as the reference level for a \code{factor} variable. Columns coded as \code{character} class are first converted to factors via \R{factor(x)}.  If \code{impute=TRUE} then the numeric columns are converted to two columns, one appended \code{.x} that contains imputed values and another appended \code{.miss} which is a binary variable indicating whether the original value was missing.  Numeric columns are returned without change if \code{impute=FALSE} or if they do not contain any missing values.  
         |
```

### Context

This task was proposed by R Core developer Kurt Hornik as part of an initiative to improve CRAN package documentation. Packages with public repositories (GitHub, GitLab, Bitbucket) and a higher number of reverse dependencies were prioritised. This PR has been completed as part of an R Dev Day at the University of Warwick on 12 Sept 2025 (see https://github.com/r-devel/r-dev-day/issues/110).